### PR TITLE
Fix for missing queue update

### DIFF
--- a/mac/Scheduler.m
+++ b/mac/Scheduler.m
@@ -117,7 +117,9 @@ classdef Scheduler < matlab.mixin.Copyable
 				modOrd = ModOrdTable(user.Rx.CQI.wideBand);
 				numPRBS = length([obj.PRBsActive.UeId] == iUser);
 				numBits = numPRBS * (modOrd*obj.PRBSymbols);
-				user.Queue.Size = user.Queue.Size - numBits;
+				% The number of bits to decrease the queue size has to be capped to 
+				% at most the current queue size, as PRBs have to be assigned whole
+				user.Queue.Size = max(user.Queue.Size - numBits, 0);
 
 			end
 			
@@ -311,7 +313,6 @@ classdef Scheduler < matlab.mixin.Copyable
 		
 		function obj = addUser(obj, UserId)
 			obj.ScheduledUsers = [obj.ScheduledUsers UserId];
-			
 		end
 		
 		function obj = removeUser(obj, UserId)

--- a/phy/refreshUsersAssociation.m
+++ b/phy/refreshUsersAssociation.m
@@ -18,7 +18,6 @@ function refreshUsersAssociation(Users, Cells, Channel, Config, timeNow)
 			% Find an empty slot and set the context and the new eNodeBID
 			iServingCell = find([Cells.NCellID] == targetEnbID);
 				
-			%Cells(iServingCell).Users(iFree) = ueContext;
 			Cells(iServingCell).associateUser(Users(iUser));
 			Users(iUser).ENodeBID = targetEnbID;
 		else


### PR DESCRIPTION
@artuso0matteo This should be enough. However, if more symbols are allocated than what is in the queue, this fix allows the queue to be negative. I think a wrapper function should be made to update the queue size that handles this. The question is where, 1. in the user object (convenient) or 2. in the traffic object (more logical)

Let me know what you think 