### PR TITLE
Added perfect channel estimation in uplink

### DIFF
--- a/Monster.m
+++ b/Monster.m
@@ -142,6 +142,12 @@ classdef Monster < matlab.mixin.Copyable
 			obj.Runtime.remainingRounds = obj.Runtime.totalRounds - obj.Runtime.currentRound - 1;
 			% Update Channel property
 			obj.Channel.setupRound(obj.Runtime.currentRound, obj.Runtime.currentTime);
+
+			% Update user property (SRS configuration)
+			for iUser = 1:length(obj.Users)
+				obj.Users(iUser).NSubframe = mod(iRound,10);
+				obj.Users(iUser).NFrame = floor((iRound+1)/10);
+			end
 		
 		end
 

--- a/enb/enbReceiverModule.m
+++ b/enb/enbReceiverModule.m
@@ -114,6 +114,8 @@ classdef enbReceiverModule < matlab.mixin.Copyable
 				ueId = uniqueUes(iUser);
 				obj.UeData(iUser).UeId = ueId;
 				obj.UeData(iUser).Waveform = obj.ReceivedSignals{ueId}.Waveform;
+				obj.UeData(iUser).PathGains = obj.ReceivedSignals{ueId}.PathGains;
+				obj.UeData(iUser).PathFilters = obj.ReceivedSignals{ueId}.PathFilters;
 			end
 		end
 		
@@ -149,6 +151,7 @@ classdef enbReceiverModule < matlab.mixin.Copyable
 				if (ue.Tx.PUSCH.Active)
 					[obj.UeData(localIndex).EstChannelGrid, obj.UeData(localIndex).NoiseEst] = ...
 						lteULChannelEstimate(struct(ue), struct(ue).PUSCH, cec, obj.UeData(localIndex).Subframe, ue.Tx.Ref.Grid);
+					[obj.UeData(localIndex).perfectChannelEst] = nrPerfectChannelEstimate(obj.UeData(localIndex).PathGains, obj.UeData(localIndex).PathFilters, ue.NULRB, 15, 0);
 				end
 			end
 		end

--- a/phy/refreshUsersAssociation.m
+++ b/phy/refreshUsersAssociation.m
@@ -18,7 +18,6 @@ function refreshUsersAssociation(Users, Cells, Channel, Config, timeNow)
 			% Find an empty slot and set the context and the new eNodeBID
 			iServingCell = find([Cells.NCellID] == targetEnbID);
 				
-			%Cells(iServingCell).Users(iFree) = ueContext;
 			Cells(iServingCell).associateUser(Users(iUser));
 			Users(iUser).ENodeBID = targetEnbID;
 		else

--- a/ue/ueTransmitterModule.m
+++ b/ue/ueTransmitterModule.m
@@ -14,6 +14,7 @@ classdef ueTransmitterModule < matlab.mixin.Copyable
 		UeObj;
 		HarqActive;
 		SRSActive;
+		SRSConfig;
 	end
 	
 	methods
@@ -41,6 +42,7 @@ classdef ueTransmitterModule < matlab.mixin.Copyable
 			%TODO: make configureable
 			obj.TxPwdBm = 23;
 			obj.resetRef();
+			obj.SRSConfig = struct('CSRS', 7, 'BSRS', 0, 'subframeConfig',9);
 		end
 		
 		function obj = setPRACH(obj, ueObj, NSubframe)
@@ -212,6 +214,8 @@ classdef ueTransmitterModule < matlab.mixin.Copyable
 
 				% Insert into resource grid
 				obj.ReGrid(srsIdx) = SRSSymbols;
+			else
+				obj.Ref.srsIdx = [];
 			end
 
 		end
@@ -230,9 +234,9 @@ classdef ueTransmitterModule < matlab.mixin.Copyable
 			% 3-8 = 5 ms
 			% 9-14 = 10 ms
 			% 15 = 1 ms
-			CSRS = 7;
-			BSRS = 0;
-			subframeConfig = 3;
+			CSRS = obj.SRSConfig.CSRS;
+			BSRS = obj.SRSConfig.BSRS;
+			subframeConfig = obj.SRSConfig.subframeConfig;
 			
 		end
 


### PR DESCRIPTION
The channel response is computed using the path gains and filters of the channel in uplink. This can be used to compute the accuracy of the channel estimation algorithm.